### PR TITLE
AirbrakeError::handleException combatibility to parent Cake ErrorHandler

### DIFF
--- a/Lib/AirbrakeError.php
+++ b/Lib/AirbrakeError.php
@@ -19,7 +19,7 @@ class AirbrakeError extends ErrorHandler
         return parent::handleError($code, $description, $file, $line, $context);
     }
     
-    public static function handleException($exception) 
+    public static function handleException(Exception $exception)
     {
     	// Call Airbrake
 		$apiKey  = Configure::read('AirbrakeCake.apiKey'); // This is required


### PR DESCRIPTION
fixed AirbrakeError::handleException to be combatible with ErrorHandler::handleException
